### PR TITLE
chore: isolate oriundi pipeline subrepo

### DIFF
--- a/.github/workflows/oriundi-radar.yml
+++ b/.github/workflows/oriundi-radar.yml
@@ -1,0 +1,175 @@
+name: Oriundi Radar Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      use_sample_data:
+        description: "Esegui in modalit\u00e0 offline (disabilita fonti esterne)"
+        type: boolean
+        default: true
+      queries:
+        description: "Query personalizzate (una per riga)"
+        required: false
+        type: string
+      registry_enabled:
+        description: "Abilita ingestione registri open data"
+        type: boolean
+        default: false
+      registry_base_url:
+        description: "Endpoint registri (obbligatorio se abilitati)"
+        required: false
+        type: string
+      registry_max_results:
+        description: "Limite risultati registry"
+        required: false
+        default: "250"
+      fuzzy_threshold:
+        description: "Soglia fuzzy matching (0-100)"
+        required: false
+        default: "88"
+
+permissions:
+  contents: read
+
+jobs:
+  run-pipeline:
+    name: Run Oriundi pipeline
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUNBUFFERED: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pipeline dependencies
+        working-directory: oriundi-radar
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[full]"
+
+      - name: Render execution config
+        env:
+          SAMPLE_MODE: ${{ inputs.use_sample_data }}
+          INPUT_QUERIES: ${{ inputs.queries }}
+          REGISTRY_ENABLED: ${{ inputs.registry_enabled }}
+          REGISTRY_URL: ${{ inputs.registry_base_url }}
+          REGISTRY_MAX_RESULTS: ${{ inputs.registry_max_results }}
+          FUZZY_THRESHOLD: ${{ inputs.fuzzy_threshold }}
+          ANYCRAWL_KEY: ${{ secrets.ORIUNDI_ANYCRAWL_KEY }}
+          ANYCRAWL_URL: ${{ secrets.ORIUNDI_ANYCRAWL_URL }}
+          ANYCRAWL_RATE_LIMIT: ${{ secrets.ORIUNDI_ANYCRAWL_RATE_LIMIT }}
+          GENEALOGIC_KEY: ${{ secrets.ORIUNDI_GENEALOGIC_KEY }}
+          GENEALOGIC_URL: ${{ secrets.ORIUNDI_GENEALOGIC_URL }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from copy import deepcopy
+          from pathlib import Path
+
+          root = Path("oriundi-radar")
+          config_path = root / "config" / "settings.gha.json"
+          output_dir = root / "output"
+          output_dir.mkdir(parents=True, exist_ok=True)
+
+          def _bool(value: str | None, *, default: bool = False) -> bool:
+              if value is None:
+                  return default
+              return value.lower() in {"1", "true", "yes", "on"}
+
+          sample_mode = _bool(os.environ.get("SAMPLE_MODE"), default=True)
+          queries_raw = (os.environ.get("INPUT_QUERIES") or "").strip()
+          queries = [line.strip() for line in queries_raw.splitlines() if line.strip()]
+          if sample_mode and not queries:
+              queries = []
+
+          config = {
+              "anycrawl": {
+                  "base_url": os.environ.get("ANYCRAWL_URL") or "https://api.anycrawl.dev/v1",
+                  "key": os.environ.get("ANYCRAWL_KEY", ""),
+                  "rate_limit_per_minute": int(os.environ.get("ANYCRAWL_RATE_LIMIT") or 60),
+              },
+              "genealogic": {
+                  "base_url": os.environ.get("GENEALOGIC_URL") or "https://api.familysearch.org",
+                  "key": os.environ.get("GENEALOGIC_KEY", ""),
+                  "rate_limit_per_minute": 60,
+              },
+              "registry": {
+                  "enabled": False,
+                  "base_url": None,
+                  "max_results": int(os.environ.get("REGISTRY_MAX_RESULTS") or 250),
+              },
+              "storage": {
+                  "duckdb_path": "data/oriundi.duckdb",
+                  "graph_store_path": "output/oriundi_graph.ttl",
+                  "export_dir": "output",
+              },
+              "ml": {
+                  "enable_language_models": False,
+                  "spacy_model": "",
+                  "fuzzy_threshold": int(os.environ.get("FUZZY_THRESHOLD") or 88),
+              },
+              "queries": queries,
+          }
+
+          if not sample_mode:
+              registry_enabled = _bool(os.environ.get("REGISTRY_ENABLED"))
+              registry_url = (os.environ.get("REGISTRY_URL") or "").strip()
+              if registry_url:
+                  config["registry"]["base_url"] = registry_url
+              config["registry"]["enabled"] = registry_enabled and bool(registry_url)
+              if not queries:
+                  config["queries"] = [
+                      "football dual citizenship prospect",
+                      "youth player italian ancestry",
+                      "san marino eligible footballer",
+                  ]
+
+          config_path.parent.mkdir(parents=True, exist_ok=True)
+          config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+          redacted = deepcopy(config)
+          if redacted["anycrawl"].get("key"):
+              redacted["anycrawl"]["key"] = "***"
+          if redacted["genealogic"].get("key"):
+              redacted["genealogic"]["key"] = "***"
+
+          redacted_path = output_dir / "run_settings.redacted.json"
+          redacted_path.write_text(json.dumps(redacted, indent=2), encoding="utf-8")
+
+          print("Config salvata in", config_path)
+          print(json.dumps(redacted, indent=2))
+          PY
+
+      - name: Run Oriundi pipeline
+        working-directory: oriundi-radar
+        run: oriundi-pipeline run --config config/settings.gha.json
+
+      - name: Show exported files
+        working-directory: oriundi-radar
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          base = Path("output")
+          if not base.exists():
+              print("Nessun output generato")
+          else:
+              for path in sorted(base.glob("**/*")):
+                  if path.is_file():
+                      print(path)
+          PY
+
+      - name: Upload pipeline artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: oriundi-radar-output
+          path: |
+            oriundi-radar/output/**
+            oriundi-radar/output
+            oriundi-radar/data/oriundi.duckdb
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -97,5 +97,8 @@ GitHub Pages può pubblicare da main//docs.
 
 I workflow schedule girano in UTC; il token GITHUB_TOKEN usa permessi configurabili (principio del minimo privilegio).
 
+## Mini-repo pipeline oriundi
 
+Il codice sperimentale per l'identificazione degli oriundi ora vive in `oriundi-radar/`.
+Consulta `oriundi-radar/README.md` per setup e dettagli architetturali.
 

--- a/oriundi-radar/.gitignore
+++ b/oriundi-radar/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.venv/
+output/
+data/
+.DS_Store
+

--- a/oriundi-radar/README.md
+++ b/oriundi-radar/README.md
@@ -23,6 +23,35 @@ oriundi-pipeline run --config config/settings.toml
 Il comando CLI produce `output/resolved_candidates.json` e `output/oriundi_graph.ttl`,
 pronti per essere condivisi con analisti e staff federale.
 
+## Esecuzione via GitHub Actions
+
+Per avviare la pipeline anche da mobile (o senza shell locale) puoi usare il
+workflow manuale `Oriundi Radar Pipeline` definito in
+`.github/workflows/oriundi-radar.yml`.
+
+1. Apri le impostazioni della repository su GitHub e aggiungi i secret che ti
+   servono:
+   - `ORIUNDI_ANYCRAWL_KEY` (obbligatorio per interrogare AnyCrawl).
+   - opzionali: `ORIUNDI_ANYCRAWL_URL`, `ORIUNDI_ANYCRAWL_RATE_LIMIT`,
+     `ORIUNDI_GENEALOGIC_KEY`, `ORIUNDI_GENEALOGIC_URL` per endpoint/quote
+     personalizzati.
+2. Vai in **Actions → Oriundi Radar Pipeline → Run workflow** e scegli le
+   opzioni:
+   - `use_sample_data` è attivo di default e fa girare la pipeline in modalità
+     offline (nessuna chiamata esterna, utile per smoke test rapidi).
+   - imposta `use_sample_data` a `false` per utilizzare le fonti reali,
+     opzionalmente fornendo query personalizzate (una per riga) e attivando i
+     registri open data (`registry_enabled` + `registry_base_url`).
+   - `fuzzy_threshold` permette di regolare la sensibilità del clustering.
+3. A fine esecuzione troverai gli artefatti scaricabili (`oriundi-radar-output`)
+   che includono `output/resolved_candidates.json`, `output/oriundi_graph.ttl` e
+   una copia redatta della configurazione usata.
+
+Il workflow installa automaticamente il pacchetto con le dipendenze opzionali,
+genera un file di configurazione temporaneo e lancia `oriundi-pipeline run`.
+Puoi quindi farlo partire anche da smartphone/tablet senza dover preparare un
+ambiente locale.
+
 ## Struttura della mini-repo
 
 ```

--- a/oriundi-radar/README.md
+++ b/oriundi-radar/README.md
@@ -1,0 +1,48 @@
+# Oriundi Radar Pipeline
+
+Pipeline modulare per supportare la FSGC nell'identificazione di calciatori potenzialmente naturalizzabili (oriundi).
+
+## Caratteristiche principali
+
+- **Ingest** da sorgenti configurabili (SERP AnyCrawl, registri anagrafici open data, ecc.).
+- **Normalizzazione** e **entity resolution** con fuzzy matching per aggregare duplicati.
+- **Enrichment** opzionale (heuristiche social, NLP spaCy) e scoring geografico.
+- **Knowledge graph** esportato in formato Turtle con `networkx` + `rdflib`.
+- **Persistenza** in DuckDB e file JSON/Parquet per analisi successive.
+
+## Setup rapido
+
+```bash
+cd oriundi-radar
+python -m venv .venv && source .venv/bin/activate
+pip install -e .  # usa -e .[full] per le dipendenze opzionali
+cp config/settings.example.toml config/settings.toml
+oriundi-pipeline run --config config/settings.toml
+```
+
+Il comando CLI produce `output/resolved_candidates.json` e `output/oriundi_graph.ttl`,
+pronti per essere condivisi con analisti e staff federale.
+
+## Struttura della mini-repo
+
+```
+oriundi-radar/
+├─ pyproject.toml
+├─ README.md
+├─ config/
+│  └─ settings.example.toml
+├─ docs/
+│  └─ oriundi_architecture.md
+├─ src/oriundi/
+│  ├─ cli.py
+│  ├─ config.py
+│  ├─ pipeline.py
+│  ├─ data_sources/
+│  ├─ enrichment/
+│  ├─ graph/
+│  └─ processing/
+└─ tests/
+   └─ test_pipeline.py
+```
+
+Per i dettagli architetturali consulta `docs/oriundi_architecture.md`.

--- a/oriundi-radar/config/settings.example.toml
+++ b/oriundi-radar/config/settings.example.toml
@@ -1,0 +1,25 @@
+[anycrawl]
+base_url = "https://api.anycrawl.dev/v1"
+key = "YOUR_ANYCRAWL_KEY"
+rate_limit_per_minute = 60
+
+[registry]
+enabled = true
+base_url = "https://data.example.com/registry"
+max_results = 250
+
+[storage]
+duckdb_path = "data/oriundi.duckdb"
+graph_store_path = "output/oriundi_graph.ttl"
+export_dir = "output"
+
+[ml]
+enable_language_models = false
+spacy_model = ""
+fuzzy_threshold = 88
+
+queries = [
+  "football dual citizenship prospect",
+  "youth player italian ancestry",
+  "san marino eligible footballer"
+]

--- a/oriundi-radar/docs/oriundi_architecture.md
+++ b/oriundi-radar/docs/oriundi_architecture.md
@@ -1,0 +1,50 @@
+# Oriundi Radar – Architettura Tecnica
+
+## Stack principale
+
+| Layer | Tecnologia | Note |
+|-------|------------|------|
+| Orchestrazione | Python 3.12 + Typer CLI | Invocazione pipeline locale o CI |
+| Configurazione | dataclass + parser TOML | Config da env/TOML con override da env |
+| Data ingest | stdlib `urllib` (fallback) + `requests` (extra) | AnyCrawl API + open data registry |
+| Storage | JSON base, DuckDB (extra) | Persistenza locale con export JSON/TTL |
+| Data Processing | stdlib (`difflib`) + optional `pandas`/`rapidfuzz` | Normalizzazione + entity resolution |
+| Enrichment | stdlib + opzionale `tqdm`/`spaCy` | Social heuristics + NLP geopolitica |
+| Knowledge Graph | writer TTL custom (base) + opzionale `networkx`/`rdflib` | Grafi multi-edge + export Turtle |
+| Testing/Lint | `pytest`, `ruff` | Suite minima per regressioni |
+
+## Flusso dati
+
+```mermaid
+flowchart TD
+    A[AnyCrawl Search] -->|JSON SERP| B[Normalize]
+    C[Open Registry] -->|CSV/JSON| B
+    B --> D[Enrichment]
+    D --> E[Entity Resolution]
+    E --> F[DuckDB]
+    E --> G[JSON Export]
+    E --> H[Knowledge Graph]
+    H --> I[Turtle TTL]
+```
+
+## Sicurezza & Compliance
+
+- **Rate limiting** configurabile per proteggere gli endpoint AnyCrawl/open data.
+- **Audit trail** tramite export JSON versionabile (Git LFS o S3 consigliati).
+- **Data minimization**: schema normalizzato limita i campi personali superflui.
+- **Privacy by design**: il modulo NLP può essere disattivato se non ci sono basi giuridiche.
+- **Integrazione legale**: log delle fonti `article.url` per supportare verifiche manuali.
+
+## Deployment suggerito
+
+1. Contenitore Docker con immagine Python slim + dipendenze dal `pyproject`.
+2. CI/CD GitHub Actions con job programmati (cron) per aggiornare gli export.
+3. Persistenza su bucket S3 (export) e database analitico DuckDB su volume montato.
+4. Opzionale: sincronizzazione `knowledge_graph.ttl` verso Neo4j o GraphDB per query avanzate.
+
+## Estensioni future
+
+- Integrazione con API FIGC/UEFA per whitelist passaporti.
+- Modulo `prefect` o `dagster` per orchestrazione multi-step.
+- Arricchimento con segnali social (Instagram follower, LinkedIn) tramite API ufficiali.
+- Dashboard `Streamlit` per consultazione interattiva degli oriundi candidati.

--- a/oriundi-radar/pyproject.toml
+++ b/oriundi-radar/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "oriundi-radar"
+version = "0.1.0"
+description = "Pipeline per identificare giocatori naturalizzabili per la nazionale sammarinese"
+authors = [{ name = "OB1", email = "team@ob1.dev" }]
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["football", "entity resolution", "knowledge graph", "pipeline"]
+classifiers = [
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+  "Topic :: Software Development :: Build Tools"
+]
+dependencies = []
+
+[project.optional-dependencies]
+full = [
+  "requests>=2.31",
+  "pandas>=2.2",
+  "duckdb>=1.0",
+  "rapidfuzz>=3.9",
+  "networkx>=3.2",
+  "rdflib>=7.0",
+  "spacy>=3.7",
+]
+dev = ["pytest>=7.4", "pytest-cov>=4.1", "ruff>=0.6"]
+
+[project.urls]
+Homepage = "https://github.com/ob1/oriundi-radar"
+
+[project.scripts]
+oriundi-pipeline = "oriundi.cli:app"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/oriundi-radar/src/oriundi/__init__.py
+++ b/oriundi-radar/src/oriundi/__init__.py
@@ -1,0 +1,6 @@
+"""Oriundi Radar pipeline package."""
+
+from .pipeline import OriundiPipeline, PipelineResult
+from .config import OriundiSettings
+
+__all__ = ["OriundiPipeline", "PipelineResult", "OriundiSettings"]

--- a/oriundi-radar/src/oriundi/cli.py
+++ b/oriundi-radar/src/oriundi/cli.py
@@ -1,0 +1,28 @@
+"""CLI entrypoint for the Oriundi pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .config import OriundiSettings
+from .pipeline import OriundiPipeline
+
+app = typer.Typer(help="Pipeline per scouting oriundi FSGC")
+
+
+@app.command()
+def run(config: Optional[Path] = typer.Option(None, help="Percorso file di configurazione")) -> None:
+    """Esegue la pipeline end-to-end."""
+
+    settings = OriundiSettings.from_file(config) if config else OriundiSettings()
+    pipeline = OriundiPipeline(settings)
+    result = pipeline.run()
+    typer.echo(f"Export completato: {result.graph_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()
+

--- a/oriundi-radar/src/oriundi/config.py
+++ b/oriundi-radar/src/oriundi/config.py
@@ -1,0 +1,147 @@
+"""Configuration models for the Oriundi pipeline."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import tomli as tomllib  # type: ignore
+
+
+@dataclass
+class APISettings:
+    base_url: str = "https://api.anycrawl.dev/v1"
+    key: str = ""
+    rate_limit_per_minute: int = 60
+
+
+@dataclass
+class RegistrySettings:
+    enabled: bool = True
+    base_url: Optional[str] = None
+    max_results: int = 200
+
+
+@dataclass
+class StorageSettings:
+    duckdb_path: Path = Path("data/oriundi.duckdb")
+    graph_store_path: Path = Path("output/oriundi_graph.ttl")
+    export_dir: Path = Path("output")
+
+
+@dataclass
+class MLSettings:
+    enable_language_models: bool = False
+    spacy_model: str = ""
+    fuzzy_threshold: int = 90
+
+
+@dataclass
+class OriundiSettings:
+    anycrawl: APISettings = field(default_factory=APISettings)
+    genealogic: APISettings = field(
+        default_factory=lambda: APISettings(base_url="https://api.familysearch.org")
+    )
+    registry: RegistrySettings = field(default_factory=RegistrySettings)
+    storage: StorageSettings = field(default_factory=StorageSettings)
+    ml: MLSettings = field(default_factory=MLSettings)
+    queries: List[str] = field(
+        default_factory=lambda: [
+            "football U20 dual nationality",
+            "player eligible italian passport",
+            "youth prospect residency san marino",
+        ]
+    )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OriundiSettings":
+        settings = cls()
+        settings._update_from_dict(data)
+        return settings
+
+    @classmethod
+    def from_file(cls, path: Path | str) -> "OriundiSettings":
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(path)
+        if path.suffix.lower() == ".json":
+            data = json.loads(path.read_text(encoding="utf-8"))
+        elif path.suffix.lower() in {".toml", ".tml"}:
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
+        else:
+            raise ValueError("Formato file non supportato. Usa TOML o JSON.")
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_env(cls, prefix: str = "ORIUNDI_") -> "OriundiSettings":
+        data: Dict[str, Any] = {}
+        for key, value in os.environ.items():
+            if not key.startswith(prefix):
+                continue
+            nested_keys = key[len(prefix) :].lower().split("__")
+            current = data
+            for part in nested_keys[:-1]:
+                current = current.setdefault(part, {})
+            current[nested_keys[-1]] = _coerce_env_value(value)
+        return cls.from_dict(data)
+
+    def ensure_directories(self) -> None:
+        self.storage.export_dir.mkdir(parents=True, exist_ok=True)
+        self.storage.duckdb_path.parent.mkdir(parents=True, exist_ok=True)
+        self.storage.graph_store_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _update_from_dict(self, data: Dict[str, Any]) -> None:
+        if "anycrawl" in data:
+            self.anycrawl = _merge_dataclass(APISettings, self.anycrawl, data["anycrawl"])
+        if "genealogic" in data:
+            self.genealogic = _merge_dataclass(
+                APISettings, self.genealogic, data["genealogic"]
+            )
+        if "registry" in data:
+            self.registry = _merge_dataclass(
+                RegistrySettings, self.registry, data["registry"]
+            )
+        if "storage" in data:
+            storage = _merge_dataclass(StorageSettings, self.storage, data["storage"])
+            storage.duckdb_path = Path(storage.duckdb_path)
+            storage.graph_store_path = Path(storage.graph_store_path)
+            storage.export_dir = Path(storage.export_dir)
+            self.storage = storage
+        if "ml" in data:
+            self.ml = _merge_dataclass(MLSettings, self.ml, data["ml"])
+        if "queries" in data:
+            self.queries = list(data["queries"])
+
+
+def _coerce_env_value(value: str) -> Any:
+    lower = value.lower()
+    if lower in {"true", "false"}:
+        return lower == "true"
+    if lower.isdigit():
+        return int(lower)
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _merge_dataclass(cls, current, overrides):
+    values = asdict(current)
+    values.update(overrides)
+    return cls(**values)
+
+
+__all__ = [
+    "APISettings",
+    "RegistrySettings",
+    "StorageSettings",
+    "MLSettings",
+    "OriundiSettings",
+]
+

--- a/oriundi-radar/src/oriundi/data_sources/__init__.py
+++ b/oriundi-radar/src/oriundi/data_sources/__init__.py
@@ -1,0 +1,12 @@
+"""Data source interfaces for the Oriundi pipeline."""
+
+from .base import DataSource, SourceMetadata
+from .web_search import AnyCrawlSearchSource
+from .open_registry import OpenRegistrySource
+
+__all__ = [
+    "DataSource",
+    "SourceMetadata",
+    "AnyCrawlSearchSource",
+    "OpenRegistrySource",
+]

--- a/oriundi-radar/src/oriundi/data_sources/base.py
+++ b/oriundi-radar/src/oriundi/data_sources/base.py
@@ -1,0 +1,30 @@
+"""Abstract base classes for Oriundi data sources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Protocol, runtime_checkable
+
+RecordBatch = List[dict]
+
+
+@dataclass(slots=True)
+class SourceMetadata:
+    """Metadata attached to a candidate record."""
+
+    source: str
+    retrieved_at: datetime
+    confidence: float
+
+
+@runtime_checkable
+class DataSource(Protocol):
+    """Protocol representing a fetchable data source."""
+
+    def fetch(self) -> Iterable[RecordBatch]:
+        """Return an iterable of record batches."""
+
+
+__all__ = ["DataSource", "SourceMetadata", "RecordBatch"]
+

--- a/oriundi-radar/src/oriundi/data_sources/open_registry.py
+++ b/oriundi-radar/src/oriundi/data_sources/open_registry.py
@@ -1,0 +1,64 @@
+"""Open data registry ingestion."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Iterable, Optional
+from urllib import request, parse
+
+from .base import DataSource, RecordBatch, SourceMetadata
+from ..config import RegistrySettings
+
+
+class OpenRegistrySource(DataSource):
+    """Fetches civil registry data exposed as CSV/JSON."""
+
+    def __init__(
+        self,
+        settings: RegistrySettings,
+        *,
+        opener: Optional[request.OpenerDirector] = None,
+    ) -> None:
+        self.settings = settings
+        self.opener = opener or request.build_opener()
+
+    def fetch(self) -> Iterable[RecordBatch]:
+        if not self.settings.enabled or not self.settings.base_url:
+            return []
+
+        try:
+            url = f"{self.settings.base_url}?{parse.urlencode({'limit': self.settings.max_results})}"
+            with self.opener.open(url, timeout=30) as response:
+                payload = response.read().decode("utf-8")
+        except Exception as exc:  # pragma: no cover - network safety
+            raise RuntimeError("Impossibile scaricare i registri open data") from exc
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:  # pragma: no cover - data issues
+            return []
+
+        records = data if isinstance(data, list) else data.get("results", [])
+        if not isinstance(records, list):
+            return []
+
+        enriched: RecordBatch = []
+        for item in records:
+            if not isinstance(item, dict):
+                continue
+            enriched.append(
+                {
+                    **item,
+                    "__metadata__": SourceMetadata(
+                        source="open_registry",
+                        retrieved_at=datetime.now(UTC),
+                        confidence=0.85,
+                    ),
+                }
+            )
+        return [enriched]
+
+
+__all__ = ["OpenRegistrySource"]
+

--- a/oriundi-radar/src/oriundi/data_sources/web_search.py
+++ b/oriundi-radar/src/oriundi/data_sources/web_search.py
@@ -1,0 +1,76 @@
+"""AnyCrawl search integration."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Iterable, List, Optional
+from urllib import request
+
+from .base import DataSource, RecordBatch, SourceMetadata
+from ..config import APISettings
+
+
+class AnyCrawlSearchSource(DataSource):
+    """Executes vertical football searches via AnyCrawl."""
+
+    def __init__(
+        self,
+        settings: APISettings,
+        queries: List[str],
+        *,
+        opener: Optional[request.OpenerDirector] = None,
+        pages: int = 1,
+        limit: int = 20,
+    ) -> None:
+        self.settings = settings
+        self.queries = queries
+        self.pages = pages
+        self.limit = limit
+        self.opener = opener or request.build_opener()
+
+    def fetch(self) -> Iterable[RecordBatch]:
+        batches: list[RecordBatch] = []
+        for query in self.queries:
+            payload = json.dumps({"query": query, "pages": self.pages, "limit": self.limit}).encode(
+                "utf-8"
+            )
+            req = request.Request(
+                f"{self.settings.base_url}/search",
+                data=payload,
+                headers=self._headers(),
+                method="POST",
+            )
+            try:
+                with self.opener.open(req, timeout=30) as response:
+                    data = json.loads(response.read().decode("utf-8"))
+            except Exception:  # pragma: no cover - network issues
+                continue
+            results = data.get("results", []) if isinstance(data, dict) else []
+            batch: RecordBatch = []
+            for item in results:
+                if not isinstance(item, dict):
+                    continue
+                batch.append(
+                    {
+                        **item,
+                        "__metadata__": SourceMetadata(
+                            source="anycrawl_search",
+                            retrieved_at=datetime.now(UTC),
+                            confidence=0.75,
+                        ),
+                    }
+                )
+            if batch:
+                batches.append(batch)
+        return batches
+
+    def _headers(self) -> dict:
+        headers = {"Content-Type": "application/json"}
+        if self.settings.key:
+            headers["Authorization"] = f"Bearer {self.settings.key}"
+        return headers
+
+
+__all__ = ["AnyCrawlSearchSource"]
+

--- a/oriundi-radar/src/oriundi/enrichment/__init__.py
+++ b/oriundi-radar/src/oriundi/enrichment/__init__.py
@@ -1,0 +1,6 @@
+"""Enrichment utilities for the Oriundi pipeline."""
+
+from .social import enrich_with_social_signals
+from .nlp import GeoEligibilityModel
+
+__all__ = ["enrich_with_social_signals", "GeoEligibilityModel"]

--- a/oriundi-radar/src/oriundi/enrichment/nlp.py
+++ b/oriundi-radar/src/oriundi/enrichment/nlp.py
@@ -1,0 +1,78 @@
+"""NLP helpers leveraging spaCy when available."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Iterable, List
+
+from ..data_sources.base import RecordBatch
+from ..config import MLSettings
+
+
+@dataclass
+class GeoEligibility:
+    """Represents inferred eligibility evidence."""
+
+    country: str
+    score: float
+    rationale: str
+
+
+class GeoEligibilityModel:
+    """Wrapper around optional spaCy pipelines for geo extraction."""
+
+    def __init__(self, settings: MLSettings) -> None:
+        self.settings = settings
+
+    @cached_property
+    def nlp(self):  # pragma: no cover - optional dependency
+        if not self.settings.enable_language_models or not self.settings.spacy_model:
+            return None
+        try:
+            import spacy
+        except ImportError as exc:  # pragma: no cover - optional import
+            raise RuntimeError(
+                "spaCy non installato. Installa l'extra 'full' per abilitare l'NLP."
+            ) from exc
+        return spacy.load(self.settings.spacy_model)
+
+    def infer(self, texts: Iterable[str]) -> List[GeoEligibility]:
+        model = self.nlp
+        if model is None:
+            return []
+        results: List[GeoEligibility] = []
+        for doc in model.pipe(texts):  # type: ignore[union-attr]
+            entities = [ent for ent in doc.ents if ent.label_ in {"GPE", "NORP"}]
+            for ent in entities:
+                results.append(
+                    GeoEligibility(
+                        country=ent.text,
+                        score=min(1.0, 0.5 + (len(ent.text) / 20)),
+                        rationale=f"Entity {ent.text} ({ent.label_})",
+                    )
+                )
+        return results
+
+    def annotate_batch(self, batch: RecordBatch) -> RecordBatch:
+        if not batch:
+            return []
+        texts = [record.get("article.text", "") for record in batch if record.get("article.text")]
+        evidence = self.infer(texts)
+        avg_score = (
+            sum(item.score for item in evidence) / len(evidence)
+            if evidence
+            else 0.0
+        )
+        notes = "; ".join(item.rationale for item in evidence)
+        annotated: RecordBatch = []
+        for record in batch:
+            updated = dict(record)
+            updated.setdefault("eligibility.geo_score", avg_score)
+            updated.setdefault("eligibility.geo_notes", notes)
+            annotated.append(updated)
+        return annotated
+
+
+__all__ = ["GeoEligibilityModel", "GeoEligibility"]
+

--- a/oriundi-radar/src/oriundi/enrichment/social.py
+++ b/oriundi-radar/src/oriundi/enrichment/social.py
@@ -1,0 +1,41 @@
+"""Utilities to enrich candidate data with social signals."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Iterable, List
+
+try:
+    from tqdm import tqdm  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    def tqdm(iterable, **_kwargs):
+        return iterable
+
+from ..data_sources.base import RecordBatch
+
+
+def enrich_with_social_signals(batches: Iterable[RecordBatch]) -> RecordBatch:
+    """Annotate candidates with synthetic social reach metrics."""
+
+    enriched: RecordBatch = []
+    for batch in tqdm(list(batches), desc="social_enrichment", unit="batch"):
+        for record in batch:
+            updated = dict(record)
+            full_name = str(updated.get("player.full_name", ""))
+            updated["social.last_check"] = datetime.now(UTC).isoformat(timespec="seconds")
+            updated["social.score"] = _heuristic_social_score(full_name)
+            enriched.append(updated)
+    return enriched
+
+
+def _heuristic_social_score(full_name: str) -> float:
+    name = full_name.lower()
+    base = 0.2 if len(name) < 5 else 0.4
+    if any(token in name for token in ("de ", "da ", "di ", "van ", "bin ")):
+        base += 0.1
+    vowels = sum(name.count(v) for v in "aeiou")
+    return round(min(1.0, base + (vowels / 20.0)), 3)
+
+
+__all__ = ["enrich_with_social_signals"]
+

--- a/oriundi-radar/src/oriundi/graph/__init__.py
+++ b/oriundi-radar/src/oriundi/graph/__init__.py
@@ -1,0 +1,5 @@
+"""Knowledge graph builders for Oriundi."""
+
+from .builder import build_graph, export_graph
+
+__all__ = ["build_graph", "export_graph"]

--- a/oriundi-radar/src/oriundi/graph/builder.py
+++ b/oriundi-radar/src/oriundi/graph/builder.py
@@ -1,0 +1,64 @@
+"""Build and export a simple knowledge graph from resolved candidates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from ..data_sources.base import RecordBatch
+
+SCHEMA_PREFIX = "@prefix oriundi: <https://oriundi.ob1.dev/schema#> ."
+ENTITY_PREFIX = "@prefix entity: <https://oriundi.ob1.dev/entity/> ."
+
+
+def build_graph(records: RecordBatch) -> Dict[str, List[dict]]:
+    nodes: Dict[str, dict] = {}
+    edges: List[dict] = []
+    for record in records:
+        node_id = record.get("entity.cluster_id") or record.get("player.full_name", "anon")
+        if node_id not in nodes:
+            nodes[node_id] = {
+                "uri": f"entity:{node_id}",
+                "label": record.get("entity.canonical_name") or record.get("player.full_name", ""),
+                "birth_date": record.get("player.birth_date"),
+                "birth_place": record.get("player.birth_place"),
+                "current_club": record.get("player.current_club"),
+            }
+        article_url = record.get("article.url")
+        if article_url:
+            edges.append(
+                {
+                    "source": f"entity:{node_id}",
+                    "target": f"<{article_url}>",
+                    "predicate": "oriundi:mentionedIn",
+                }
+            )
+    return {"nodes": list(nodes.values()), "edges": edges}
+
+
+def export_graph(graph: Dict[str, List[dict]], destination: Path) -> None:
+    lines: List[str] = [SCHEMA_PREFIX, ENTITY_PREFIX, ""]
+    for node in graph.get("nodes", []):
+        uri = node["uri"]
+        lines.append(f"{uri} a oriundi:Player ;")
+        if node.get("label"):
+            lines.append(f'    oriundi:label "{node["label"]}" ;')
+        if node.get("birth_date"):
+            lines.append(f'    oriundi:birthDate "{node["birth_date"]}" ;')
+        if node.get("birth_place"):
+            lines.append(f'    oriundi:birthPlace "{node["birth_place"]}" ;')
+        if node.get("current_club"):
+            lines.append(f'    oriundi:currentClub "{node["current_club"]}" ;')
+        if lines[-1].endswith(";"):
+            lines[-1] = lines[-1][:-1] + "."
+        else:
+            lines.append(".")
+        lines.append("")
+    for edge in graph.get("edges", []):
+        lines.append(f"{edge['source']} {edge['predicate']} {edge['target']} .")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text("\n".join(lines), encoding="utf-8")
+
+
+__all__ = ["build_graph", "export_graph"]
+

--- a/oriundi-radar/src/oriundi/pipeline.py
+++ b/oriundi-radar/src/oriundi/pipeline.py
@@ -1,0 +1,85 @@
+"""High-level orchestration for the Oriundi pipeline."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from .config import OriundiSettings
+from .data_sources import AnyCrawlSearchSource, DataSource, OpenRegistrySource
+from .data_sources.base import RecordBatch
+from .enrichment import GeoEligibilityModel, enrich_with_social_signals
+from .graph import build_graph, export_graph
+from .processing import normalize_candidates, resolve_candidates
+
+
+@dataclass(slots=True)
+class PipelineResult:
+    resolved_records: RecordBatch
+    graph_path: Path
+    resolved_path: Path
+
+
+class OriundiPipeline:
+    """Composable ETL pipeline for oriundi scouting."""
+
+    def __init__(
+        self,
+        settings: OriundiSettings,
+        sources: Sequence[DataSource] | None = None,
+    ) -> None:
+        self.settings = settings
+        self.settings.ensure_directories()
+        self.sources = list(sources) if sources is not None else self._default_sources()
+
+    def _default_sources(self) -> list[DataSource]:
+        anycrawl_source = AnyCrawlSearchSource(
+            self.settings.anycrawl, self.settings.queries, pages=1, limit=25
+        )
+        registry_source = OpenRegistrySource(self.settings.registry)
+        return [anycrawl_source, registry_source]
+
+    def run(self) -> PipelineResult:
+        raw_batches = []
+        for source in self.sources:
+            raw_batches.extend(source.fetch())
+
+        normalized = normalize_candidates(raw_batches)
+        enriched = enrich_with_social_signals([normalized])
+        geo_model = GeoEligibilityModel(self.settings.ml)
+        enriched = geo_model.annotate_batch(enriched)
+        resolved = resolve_candidates(enriched, threshold=self.settings.ml.fuzzy_threshold)
+        graph = build_graph(resolved)
+        export_graph(graph, self.settings.storage.graph_store_path)
+        self._persist_to_duckdb(resolved)
+        export_path = self._export_resolved(resolved)
+        return PipelineResult(
+            resolved_records=resolved,
+            graph_path=self.settings.storage.graph_store_path,
+            resolved_path=export_path,
+        )
+
+    def _export_resolved(self, records: RecordBatch) -> Path:
+        export_path = self.settings.storage.export_dir / "resolved_candidates.json"
+        export_path.write_text(json.dumps(records, ensure_ascii=False, indent=2), encoding="utf-8")
+        return export_path
+
+    def _persist_to_duckdb(self, records: RecordBatch) -> None:
+        if not records:
+            return
+        try:
+            import duckdb  # type: ignore
+        except ImportError:  # pragma: no cover - optional dependency
+            return
+        con = duckdb.connect(str(self.settings.storage.duckdb_path))
+        con.execute("CREATE TABLE IF NOT EXISTS candidates (payload JSON)")
+        con.execute("DELETE FROM candidates")
+        for record in records:
+            con.execute("INSERT INTO candidates VALUES (?)", [json.dumps(record)])
+        con.close()
+
+
+__all__ = ["OriundiPipeline", "PipelineResult"]
+

--- a/oriundi-radar/src/oriundi/processing/__init__.py
+++ b/oriundi-radar/src/oriundi/processing/__init__.py
@@ -1,0 +1,6 @@
+"""Data processing utilities for Oriundi."""
+
+from .normalization import normalize_candidates
+from .entity_resolution import resolve_candidates
+
+__all__ = ["normalize_candidates", "resolve_candidates"]

--- a/oriundi-radar/src/oriundi/processing/entity_resolution.py
+++ b/oriundi-radar/src/oriundi/processing/entity_resolution.py
@@ -1,0 +1,69 @@
+"""Entity resolution utilities for candidate consolidation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import List
+
+from ..data_sources.base import RecordBatch
+
+
+@dataclass(frozen=True)
+class ResolutionResult:
+    """Cluster metadata for resolved entities."""
+
+    canonical_name: str
+    score: float
+    members: List[int]
+
+
+def resolve_candidates(records: RecordBatch, threshold: int = 90) -> RecordBatch:
+    """Perform simple clustering using difflib ratio."""
+
+    if not records:
+        return []
+    visited: set[int] = set()
+    clusters: list[ResolutionResult] = []
+    for idx, record in enumerate(records):
+        if idx in visited:
+            continue
+        canonical = record.get("player.full_name", "").strip()
+        members = [idx]
+        for other_idx in range(idx + 1, len(records)):
+            if other_idx in visited:
+                continue
+            other_name = records[other_idx].get("player.full_name", "").strip()
+            if not other_name:
+                continue
+            score = SequenceMatcher(None, canonical.lower(), other_name.lower()).ratio() * 100
+            if score >= threshold:
+                members.append(other_idx)
+                visited.add(other_idx)
+                canonical = _merge_names(canonical, other_name)
+        visited.add(idx)
+        clusters.append(
+            ResolutionResult(
+                canonical_name=canonical or record.get("player.full_name", ""),
+                score=1.0,
+                members=members,
+            )
+        )
+    resolved: RecordBatch = []
+    for cluster_idx, cluster in enumerate(clusters, start=1):
+        for member_idx in cluster.members:
+            updated = dict(records[member_idx])
+            updated["entity.canonical_name"] = cluster.canonical_name
+            updated["entity.cluster_id"] = f"C{cluster_idx:03d}"
+            updated["entity.cluster_size"] = len(cluster.members)
+            resolved.append(updated)
+    return resolved
+
+
+def _merge_names(name_a: str, name_b: str) -> str:
+    parts = set(filter(None, (name_a or "").split() + (name_b or "").split()))
+    return " ".join(sorted(parts))
+
+
+__all__ = ["resolve_candidates", "ResolutionResult"]
+

--- a/oriundi-radar/src/oriundi/processing/normalization.py
+++ b/oriundi-radar/src/oriundi/processing/normalization.py
@@ -1,0 +1,60 @@
+"""Normalization helpers for candidate data."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Iterable, List
+
+from ..data_sources.base import RecordBatch
+
+EXPECTED_KEYS = {
+    "player.full_name",
+    "player.birth_date",
+    "player.birth_place",
+    "player.current_club",
+    "player.position",
+    "article.url",
+    "article.text",
+}
+
+
+def normalize_candidates(batches: Iterable[RecordBatch]) -> RecordBatch:
+    """Normalize heterogenous batches into a canonical schema."""
+
+    normalized: RecordBatch = []
+    for batch in batches:
+        for record in batch:
+            normalized.append(_normalize_record(record))
+    return normalized
+
+
+def _normalize_record(record: dict) -> dict:
+    normalized = {key: record.get(key) for key in EXPECTED_KEYS}
+    normalized["player.full_name"] = _clean_name(normalized.get("player.full_name") or "")
+    normalized["player.birth_date"] = _parse_date(normalized.get("player.birth_date"))
+    normalized["article.url"] = (normalized.get("article.url") or "").strip()
+    normalized["ingestion.batch_at"] = datetime.now(UTC).isoformat(timespec="seconds")
+    normalized.update({k: v for k, v in record.items() if k not in normalized})
+    return normalized
+
+
+def _clean_name(value: str) -> str:
+    return " ".join(value.strip().split())
+
+
+def _parse_date(value):
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, str):
+        for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%m/%d/%Y"):
+            try:
+                return datetime.strptime(value, fmt).date().isoformat()
+            except ValueError:
+                continue
+    return None
+
+
+__all__ = ["normalize_candidates"]
+

--- a/oriundi-radar/tests/conftest.py
+++ b/oriundi-radar/tests/conftest.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+

--- a/oriundi-radar/tests/test_pipeline.py
+++ b/oriundi-radar/tests/test_pipeline.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from oriundi.config import OriundiSettings
+from oriundi.pipeline import OriundiPipeline
+from oriundi.data_sources.base import DataSource, RecordBatch
+
+
+class FakeSource:
+    def __init__(self, batch: RecordBatch) -> None:
+        self.batch = batch
+
+    def fetch(self):
+        return [self.batch]
+
+
+@pytest.fixture()
+def candidate_batch() -> RecordBatch:
+    return [
+        {
+            "player.full_name": "Marco De Rossi",
+            "player.birth_date": "2004-05-12",
+            "player.birth_place": "Buenos Aires",
+            "player.current_club": "Club Atletico",
+            "player.position": "MF",
+            "article.url": "https://example.com/a",
+            "article.text": "Marco De Rossi scored and has Italian heritage.",
+        },
+        {
+            "player.full_name": "Marco DeRossi",
+            "player.birth_date": "12/05/2004",
+            "player.birth_place": "Buenos Aires",
+            "player.current_club": "Club Atletico",
+            "player.position": "MF",
+            "article.url": "https://example.com/b",
+            "article.text": "Il talento argentino Marco De Rossi parla italiano.",
+        },
+    ]
+
+
+def test_pipeline_runs_with_fake_source(tmp_path: Path, candidate_batch: RecordBatch) -> None:
+    settings = OriundiSettings.from_dict(
+        {
+            "storage": {
+                "duckdb_path": str(tmp_path / "oriundi.duckdb"),
+                "graph_store_path": str(tmp_path / "graph.ttl"),
+                "export_dir": str(tmp_path),
+            },
+            "ml": {"fuzzy_threshold": 85},
+        }
+    )
+    pipeline = OriundiPipeline(settings, sources=[FakeSource(candidate_batch)])
+    result = pipeline.run()
+
+    assert result.graph_path.exists()
+    assert result.resolved_path.exists()
+    assert len(result.resolved_records) == 2
+    assert any(record["entity.cluster_size"] == 2 for record in result.resolved_records)
+


### PR DESCRIPTION
## Summary
- move the oriundi pipeline package, docs, config, and tests into a dedicated `oriundi-radar/` subdirectory to model a standalone repository
- add documentation and ignore rules inside the new subrepo with setup instructions for running the pipeline
- update the root README to reference the relocated pipeline materials

## Testing
- `pytest oriundi-radar/tests`


------
https://chatgpt.com/codex/tasks/task_e_68d0deb35f3c8321b1d167151b12093b