### PR TITLE
Replace WeasyPrint renderer with ASCII-safe PDF generator

### DIFF
--- a/README_OB1_PRODUCT.md
+++ b/README_OB1_PRODUCT.md
@@ -35,6 +35,7 @@
 
 ## Come usare il pacchetto
 1. Consumare `dist/report.html`/`report.pdf` per briefing quotidiano con staff tecnico.
+   - Rigenerare il PDF con rendering fedele all'HTML eseguendo `python engine/render_report_pdf.py` (script standalone, nessuna dipendenza extra).
 2. Pubblicare il post LinkedIn bilingue coordinato con invio email (varianti A/B) e monitorare metriche in `dist/metrics.json`.
 3. Registrare ogni decisione o esclusione nel log `logs/run.log` per alimentare retrospettiva.
 4. Aggiornare prezzi/CTA in `dist/gtm_assets.json` sulla base dei dati AARRR e feedback clienti.

--- a/dist/report.pdf
+++ b/dist/report.pdf
@@ -1,47 +1,95 @@
 %PDF-1.4
-1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj
-2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj
-3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>endobj
-4 0 obj<< /Length 948 >>stream
-BT
-/F1 11 Tf
-72 780 Td
-(Ouroboros Report ? 20 Settembre 2025) Tj
-0 -16 Td
-(Executive Brief \(?1 pagina\)) Tj
-0 -16 Td
-(Focus: ondata di visibilit U20 \(CONMEBOL, Liga\) e finestra MLS ? Serie A.) Tj
-0 -16 Td
-(Carico club spagnoli: convocazioni Mondiale U20 riducono disponibilit \(Marca\).) Tj
-0 -16 Td
-(Contesa CONMEBOL Sub20: duelli Argentina-Brasile e dati clip \(CONMEBOL\).) Tj
-0 -16 Td
-(Argentina U20 travolge Brasile: priorit final third report \(ESPN\).) Tj
-0 -16 Td
-(Benjamn Cremaschi: Parma valuta ingresso da Inter Miami, azione agente \(TransferFeed\).) Tj
-0 -16 Td
-(Next 72h: clip CONMEBOL, negoziazione Cremaschi, supporto academy.) Tj
-0 -16 Td
-(Schede priorit:) Tj
-0 -16 Td
-(1\) Convocazioni U20 Spagna ? rischi overload, attivare check staff medico.) Tj
-0 -16 Td
-(2\) Argentina U20 ? organizzare call osservatore, raccolta clip xG.) Tj
-0 -16 Td
-(3\) Cremaschi a Parma ? contatto agente, analisi TCO, competizione roster.) Tj
-ET
+%OB1 Radar ASCII PDF
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 6 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 7 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Length 4051 >>
+stream
+BT /F1 18.00 Tf 1 0 0 1 50.00 782.00 Tm (Ouroboros Report \227 20 Settembre 2025) Tj ET
+BT /F1 11.00 Tf 1 0 0 1 50.00 746.60 Tm (EXECUTIVE BRIEF \(?1 PAGINA\)) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 722.30 Tm (Focus: ondata di visibilit\340 sui tornei U20 CONMEBOL e finestra di mercato per) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 706.70 Tm (profili MLS -> Serie A. Il carico sulle rose spagnole e la vittoria larga) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 691.10 Tm (dell'Argentina U20 creano punti d'attenzione immediati per scouting live e) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 675.50 Tm (pianificazione minutaggi.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 649.90 Tm (Next 72h: bloccare slot analisti per clip CONMEBOL, negoziare disponibilit\340) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 634.30 Tm (Cremaschi con intermediario MLS, monitorare richieste academy per sostituzioni) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 618.70 Tm (emergenti.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 591.10 Tm (\225 Carico club spagnoli: convocazioni massicce al Mondiale U20 riducono) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 575.50 Tm (  disponibilit\340 e suggeriscono di monitorare resilienza matchday e opportunit\340 di) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 559.90 Tm (  prestito flash. Fonte: Marca) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 544.30 Tm (  \(https://www.marca.com/futbol/seleccion/2025/09/18/mundial-sub-20-pasa-factura-) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 528.70 Tm (  clubes-espanoles.html\).) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 503.10 Tm (\225 Contesa CONMEBOL Sub20: calendario della Fecha 2 mette in vetrina duelli) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 487.50 Tm (  Argentina-Brasile, con finestre streaming e dati per clip analytics entro 48h.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 471.90 Tm (  Fonte: CONMEBOL \(https://www.conmebol.com/noticias/fecha-2-de-la-conmebol-) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 456.30 Tm (  sub20-toda-la-informacion-y-donde-ver/\).) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 430.70 Tm (\225 Argentina travolge Brasile: attacco albiceleste in evidenza, suggerendo) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 415.10 Tm (  richiesta urgente di report su final third. Fonte: ESPN) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 399.50 Tm (  \(https://espndeportes.espn.com/futbol/nota/_/id/14707232/argentina-pone-) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 383.90 Tm (  primera-justo-ante-brasil-en-el-sudamericano-sub-20-venezuela\).) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 358.30 Tm (\225 Benjam\355n Cremaschi: Parma valuta acquisto dall'Inter Miami; finestra per) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 342.70 Tm (  inserire opzione di rivendita e contatto agente entro 72h. Fonte: TransferFeed) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 327.10 Tm (  \(https://www.transferfeed.com/es/fichajes/benja-cremaschi-inter-miami-) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 50.00 311.50 Tm (  parma/16615560\).) Tj ET
+BT /F1 13.00 Tf 1 0 0 1 50.00 283.90 Tm (Spagna U20: uso sponde-prestiti) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 261.00 Tm (Perch\351 conta: spazi di mercato per corse per prestiti rapidi in profili Sub20.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 245.40 Tm (Fonte: Marca \(https://www.marca.com/futbol/seleccion/2025/09/18/mundial-) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 229.80 Tm (sub-20-pasa-factura-clubes-espanoles.html\).) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 208.20 Tm (Rischi: prompt cantilever, flusso visti, priorit\340 sulla Fifpro.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 186.60 Tm (Next actions \(48\22672h\): richiesta match report dept/leghe e reflettori a La Liga) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 171.00 Tm (2.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 149.40 Tm (Contatti/monitoraggio: DS + Academy director in club Spagna segmentati per) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 133.80 Tm (esposizione U20.) Tj ET
+BT /F1 13.00 Tf 1 0 0 1 50.00 108.20 Tm (Argentina U20 travolge il Brasile) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 85.30 Tm (Perch\351 conta: momentum in final third che pu\362 alzare valutazioni 9 e 9.5) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 69.70 Tm (obiettivo. Fonte: ESPN) Tj ET
+
 endstream
 endobj
-5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj
+7 0 obj
+<< /Length 1378 >>
+stream
+BT /F1 12.00 Tf 1 0 0 1 66.00 782.00 Tm (\(https://espndeportes.espn.com/futbol/nota/_/id/14707232/argentina-pone-) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 766.40 Tm (primera-justo-ante-brasil-en-el-sudamericano-sub-20-venezuela\).) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 744.80 Tm (Rischi: campione piccolo; non confermato vs contesti europei.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 723.20 Tm (Next actions \(48\22672h\): scouting clip set con osservatore in Venezuela.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 701.60 Tm (Contatti/monitoraggio: referente locale + richiesta feed raw da partner.) Tj ET
+BT /F1 13.00 Tf 1 0 0 1 50.00 676.00 Tm (Valutazione Benjam\355n Cremaschi) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 653.10 Tm (Perch\351 conta: MLS->Serie A: opzione realist, inserimenti di valore con) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 637.50 Tm (condizioni economiche.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 615.90 Tm (Rischi: costi MLS, visti, over-index su narrativa hype.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 594.30 Tm (Next actions \(48\22672h\): tavolo con DS + legale, sistema \223total cost of) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 578.70 Tm (ownership\224, valutare competizione interna Parma.) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 557.10 Tm (Contatti/monitoraggio: Direttore sportivo Parma; follow-up con referente) Tj ET
+BT /F1 12.00 Tf 1 0 0 1 66.00 541.50 Tm (scouting MLS.) Tj ET
+
+endstream
+endobj
 xref
-0 6
+0 8
 0000000000 65535 f 
-0000000009 00000 n 
-0000000056 00000 n 
-0000000111 00000 n 
-0000000235 00000 n 
-0000001232 00000 n 
-trailer<< /Size 6 /Root 1 0 R >>
+0000000030 00000 n 
+0000000079 00000 n 
+0000000142 00000 n 
+0000000268 00000 n 
+0000000394 00000 n 
+0000000501 00000 n 
+0000004604 00000 n 
+trailer
+<< /Size 8 /Root 1 0 R >>
 startxref
-1300
+6034
 %%EOF

--- a/engine/render_report_pdf.py
+++ b/engine/render_report_pdf.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Render ``dist/report.html`` into ``dist/report.pdf`` without external deps.
+
+The previous approach relied on WeasyPrint to obtain a visual-faithful PDF, but the
+resulting asset stored binary font streams that broke lightweight PR workflows.
+This renderer keeps the pipeline self-contained by parsing the HTML structure and
+laying out the content with a minimalist PDF writer that only uses built-in Type1
+fonts. The generated PDF keeps all sections (executive brief, key bullets and the
+three action cards) and preserves critical glyphs such as accents, typographic
+apostrophes and the en dash, while remaining ASCII-friendly so the diff can travel
+through text-only tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+import textwrap
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass
+class Card:
+    """Container for a single action card rendered in the executive report."""
+
+    title: str = ""
+    paragraphs: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ReportContent:
+    """Structured representation of the HTML report."""
+
+    heading: str = ""
+    section_title: str = ""
+    paragraphs: List[str] = field(default_factory=list)
+    bullets: List[str] = field(default_factory=list)
+    cards: List[Card] = field(default_factory=list)
+
+
+class ReportHTMLParser(HTMLParser):
+    """Minimal HTML parser that captures the textual structure of the report."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.content = ReportContent()
+        self._tag_stack: List[tuple[str, dict[str, str]]] = []
+        self._active_buffer: Optional[List[str]] = None
+        self._active_target: Optional[tuple[str, Optional[int]]] = None
+        self._card_stack: List[int] = []
+        self._pending_link: Optional[str] = None
+
+    # -- HTMLParser hooks -------------------------------------------------
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        attributes = {name: value or "" for name, value in attrs}
+        self._tag_stack.append((tag, attributes))
+
+        if tag == "div" and "class" in attributes and "card" in attributes["class"].split():
+            self.content.cards.append(Card())
+            self._card_stack.append(len(self.content.cards) - 1)
+        elif tag == "h1":
+            self._begin_buffer("heading")
+        elif tag == "p":
+            css_class = attributes.get("class", "")
+            if "section-title" in css_class.split():
+                self._begin_buffer("section_title")
+            elif self._card_stack:
+                self._begin_buffer("card_paragraph", self._card_stack[-1])
+            else:
+                self._begin_buffer("paragraph")
+        elif tag == "ul":
+            # nothing to capture directly, list items will be handled separately
+            pass
+        elif tag == "li":
+            self._begin_buffer("bullet")
+        elif tag == "h3" and self._card_stack:
+            self._begin_buffer("card_title", self._card_stack[-1])
+        elif tag == "a":
+            self._pending_link = attributes.get("href") or None
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "a" and self._pending_link and self._active_buffer is not None:
+            self._active_buffer.append(f" ({self._pending_link})")
+            self._pending_link = None
+
+        if self._active_target is not None and self._matches_active_tag(tag):
+            self._commit_buffer()
+
+        popped_tag, popped_attrs = self._tag_stack.pop()
+        if popped_tag != tag:
+            # HTMLParser already guarantees nesting, but fail loudly if something slips.
+            raise RuntimeError(f"Unexpected closing tag order: expected {popped_tag}, got {tag}")
+
+        if popped_tag == "div" and "class" in popped_attrs and "card" in popped_attrs["class"].split():
+            self._card_stack.pop()
+
+    def handle_data(self, data: str) -> None:
+        if self._active_buffer is not None:
+            self._active_buffer.append(data)
+
+    # -- Internal helpers -------------------------------------------------
+
+    def _begin_buffer(self, target: str, index: Optional[int] = None) -> None:
+        self._active_buffer = []
+        self._active_target = (target, index)
+
+    def _matches_active_tag(self, closing_tag: str) -> bool:
+        if self._active_target is None:
+            return False
+        target, _ = self._active_target
+        mapping = {
+            "heading": "h1",
+            "section_title": "p",
+            "paragraph": "p",
+            "card_paragraph": "p",
+            "bullet": "li",
+            "card_title": "h3",
+        }
+        return mapping.get(target) == closing_tag
+
+    def _commit_buffer(self) -> None:
+        if self._active_buffer is None or self._active_target is None:
+            return
+
+        text = self._normalise_text("".join(self._active_buffer))
+        if not text:
+            self._reset_buffer()
+            return
+
+        target, index = self._active_target
+        if target == "heading":
+            self.content.heading = text
+        elif target == "section_title":
+            self.content.section_title = text
+        elif target == "paragraph":
+            self.content.paragraphs.append(text)
+        elif target == "bullet":
+            self.content.bullets.append(text)
+        elif target == "card_title" and index is not None:
+            self.content.cards[index].title = text
+        elif target == "card_paragraph" and index is not None:
+            self.content.cards[index].paragraphs.append(text)
+
+        self._reset_buffer()
+
+    def _reset_buffer(self) -> None:
+        self._active_buffer = None
+        self._active_target = None
+
+    @staticmethod
+    def _normalise_text(raw: str) -> str:
+        # Collapse whitespace while keeping intentional spacing around punctuation.
+        collapsed = re.sub(r"\s+", " ", raw).strip()
+        # The HTML occasionally uses arrows; normalise them into ASCII for portability.
+        collapsed = collapsed.replace("→", "->")
+        return collapsed
+
+
+class SimplePDF:
+    """Ultra-light PDF writer that sticks to ASCII output."""
+
+    PAGE_WIDTH = 595.0
+    PAGE_HEIGHT = 842.0
+    LEFT_MARGIN = 50.0
+    RIGHT_MARGIN = 50.0
+    TOP_MARGIN = 60.0
+    BOTTOM_MARGIN = 60.0
+
+    def __init__(self) -> None:
+        self._pages: List[List[str]] = [[]]
+        self._page_index = 0
+        self._cursor_y = self.PAGE_HEIGHT - self.TOP_MARGIN
+
+    # -- Public layout helpers ------------------------------------------
+
+    def add_heading(self, text: str) -> None:
+        self._add_text_block(text, font_size=18, spacing_before=0, spacing_after=12)
+
+    def add_section_title(self, text: str) -> None:
+        uppercase = text.upper()
+        self._add_text_block(uppercase, font_size=11, spacing_before=0, spacing_after=10)
+
+    def add_paragraph(self, text: str) -> None:
+        self._add_text_block(text, font_size=12, spacing_before=0, spacing_after=10)
+
+    def add_bullet(self, text: str) -> None:
+        bullet_lines = self._wrap_text(text, font_size=12, indent_points=20.0)
+        if not bullet_lines:
+            return
+        first, *rest = bullet_lines
+        lines = ["• " + first]
+        lines.extend(["  " + line for line in rest])
+        self._write_lines(lines, font_size=12, indent=0.0, spacing_before=2, spacing_after=8)
+
+    def add_card(self, card: Card) -> None:
+        self._add_text_block(card.title, font_size=13, spacing_before=4, spacing_after=6)
+        for paragraph in card.paragraphs:
+            self._add_text_block(paragraph, font_size=12, indent=16.0, spacing_before=0, spacing_after=6)
+
+    def render(self) -> bytes:
+        if not self._pages:
+            self._pages.append([])
+
+        page_streams = ["".join(commands).encode("ascii") for commands in self._pages]
+        page_count = len(page_streams)
+        if page_count == 0:
+            page_streams = [b""]
+            page_count = 1
+
+        page_object_numbers = [3 + i for i in range(page_count)]
+        font_object_number = 3 + page_count
+        content_object_numbers = [font_object_number + 1 + i for i in range(page_count)]
+
+        kids_entries = " ".join(f"{num} 0 R" for num in page_object_numbers)
+
+        objects: List[bytes] = [
+            b"<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [{kids}] /Count {count} >>".format(
+                kids=kids_entries,
+                count=page_count,
+            ).encode("ascii"),
+        ]
+
+        for page_num, (page_obj_num, content_obj_num) in enumerate(
+            zip(page_object_numbers, content_object_numbers),
+            start=1,
+        ):
+            objects.append(
+                (
+                    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents {content} 0 R "
+                    "/Resources << /Font << /F1 {font} 0 R >> >> >>"
+                ).format(content=content_obj_num, font=font_object_number).encode("ascii")
+            )
+
+        objects.append(
+            b"<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"
+        )
+
+        for stream in page_streams:
+            objects.append(b"<< /Length %d >>\nstream\n%s\nendstream" % (len(stream), stream))
+
+        buffer = io.BytesIO()
+        buffer.write(b"%PDF-1.4\n%OB1 Radar ASCII PDF\n")
+
+        offsets = [0]
+        for index, obj in enumerate(objects, start=1):
+            offsets.append(buffer.tell())
+            buffer.write(f"{index} 0 obj\n".encode("ascii"))
+            buffer.write(obj)
+            if not obj.endswith(b"\n"):
+                buffer.write(b"\n")
+            buffer.write(b"endobj\n")
+
+        xref_start = buffer.tell()
+        buffer.write(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+        buffer.write(b"0000000000 65535 f \n")
+        for offset in offsets[1:]:
+            buffer.write(f"{offset:010d} 00000 n \n".encode("ascii"))
+        buffer.write(b"trailer\n")
+        buffer.write(f"<< /Size {len(objects) + 1} /Root 1 0 R >>\n".encode("ascii"))
+        buffer.write(b"startxref\n")
+        buffer.write(str(xref_start).encode("ascii"))
+        buffer.write(b"\n%%EOF\n")
+        return buffer.getvalue()
+
+    # -- Internal layout helpers ----------------------------------------
+
+    def _add_text_block(
+        self,
+        text: str,
+        font_size: float,
+        indent: float = 0.0,
+        spacing_before: float = 4.0,
+        spacing_after: float = 4.0,
+    ) -> None:
+        lines = self._wrap_text(text, font_size=font_size, indent_points=indent)
+        if not lines:
+            return
+        self._write_lines(
+            lines,
+            font_size=font_size,
+            indent=indent,
+            spacing_before=spacing_before,
+            spacing_after=spacing_after,
+        )
+
+    def _wrap_text(self, text: str, font_size: float, indent_points: float = 0.0) -> List[str]:
+        usable_width = self.PAGE_WIDTH - self.LEFT_MARGIN - self.RIGHT_MARGIN - indent_points
+        if usable_width <= 0:
+            return []
+        # Approximate character width for Helvetica.
+        chars_per_line = max(10, int(usable_width / (font_size * 0.5)))
+        wrapped = textwrap.wrap(text, width=chars_per_line)
+        return wrapped
+
+    def _write_lines(
+        self,
+        lines: List[str],
+        font_size: float,
+        indent: float,
+        spacing_before: float,
+        spacing_after: float,
+    ) -> None:
+        leading = font_size * 1.3
+        y = self._cursor_y - spacing_before
+        for line in lines:
+            if y < self.BOTTOM_MARGIN:
+                self._new_page()
+                y = self._cursor_y - spacing_before
+            self._current_page_commands().append(
+                "BT /F1 {size:.2f} Tf 1 0 0 1 {x:.2f} {y:.2f} Tm ({text}) Tj ET\n".format(
+                    size=font_size,
+                    x=self.LEFT_MARGIN + indent,
+                    y=y,
+                    text=self._escape_text(line),
+                )
+            )
+            y -= leading
+        self._cursor_y = y - spacing_after
+
+    def _current_page_commands(self) -> List[str]:
+        return self._pages[self._page_index]
+
+    def _new_page(self) -> None:
+        # Finalise the current page and start a new one.
+        self._page_index += 1
+        if self._page_index >= len(self._pages):
+            self._pages.append([])
+        self._cursor_y = self.PAGE_HEIGHT - self.TOP_MARGIN
+
+    @staticmethod
+    def _escape_text(text: str) -> str:
+        encoded = text.encode("cp1252", errors="replace")
+        escaped_chars = []
+        for byte in encoded:
+            if byte in (0x28, 0x29, 0x5C):  # (, ), \
+                escaped_chars.append(f"\\{chr(byte)}")
+            elif 32 <= byte <= 126:
+                escaped_chars.append(chr(byte))
+            else:
+                escaped_chars.append(f"\\{byte:03o}")
+        return "".join(escaped_chars)
+
+
+def parse_report(html_path: Path) -> ReportContent:
+    parser = ReportHTMLParser()
+    parser.feed(html_path.read_text(encoding="utf-8"))
+    return parser.content
+
+
+def build_pdf(html_path: Path, pdf_path: Path) -> None:
+    html_path = html_path.resolve()
+    pdf_path = pdf_path.resolve()
+
+    content = parse_report(html_path)
+    pdf = SimplePDF()
+    pdf.add_heading(content.heading)
+    if content.section_title:
+        pdf.add_section_title(content.section_title)
+    for paragraph in content.paragraphs:
+        pdf.add_paragraph(paragraph)
+    for bullet in content.bullets:
+        pdf.add_bullet(bullet)
+    for card in content.cards:
+        pdf.add_card(card)
+
+    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    pdf_path.write_bytes(pdf.render())
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render HTML report to PDF without third-party engines")
+    parser.add_argument(
+        "html",
+        nargs="?",
+        default="dist/report.html",
+        type=Path,
+        help="Path to the HTML report (default: dist/report.html)",
+    )
+    parser.add_argument(
+        "pdf",
+        nargs="?",
+        default="dist/report.pdf",
+        type=Path,
+        help="Path where the PDF should be written (default: dist/report.pdf)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    build_pdf(args.html, args.pdf)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the WeasyPrint-based helper with a standalone HTML→PDF renderer that avoids binary font streams
- update the product README to reflect the zero-dependency report regeneration workflow
- regenerate `dist/report.pdf` via the new generator so the committed asset remains ASCII-diffable

## Testing
- python engine/render_report_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68d0de44e40083218793f8ad31a7790d