### PR TITLE
Add Paddle checkout links and success page

### DIFF
--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -67,9 +67,10 @@
           <li>✓ Alert Telegram giornalieri</li>
         </ul>
         <div>
-          <button class="btn btn-primary" onclick="openCheckout('monthly')">
+          <a class="btn btn-primary"
+             href="https://checkout.paddle.com/checkout?price_id=pri_01k4ev94snz6naqdj8221qgh0q&quantity=1&success=https%3A%2F%2Fmatchanalysispro.online%2Fsuccess.html&passthrough=%7B%22plan%22%3A%22pro-monthly%22%2C%22source%22%3A%22site%22%7D">
             Attiva → €2.500/mese
-          </button>
+          </a>
         </div>
         <div class="muted">IVA inclusa ove applicabile. Disdici quando vuoi.</div>
       </section>
@@ -86,9 +87,10 @@
           <li>✓ White-label option</li>
         </ul>
         <div>
-          <button class="btn btn-primary" onclick="openCheckout('annual')">
+          <a class="btn btn-primary"
+             href="https://checkout.paddle.com/checkout?price_id=pri_01k4j50pa45x9t0gw887w3q9sz&quantity=1&success=https%3A%2F%2Fmatchanalysispro.online%2Fsuccess.html&passthrough=%7B%22plan%22%3A%22pro-annual%22%2C%22source%22%3A%22site%22%7D">
             Attiva → €25.000/anno
-          </button>
+          </a>
         </div>
         <div class="muted">Fatturazione annuale con Paddle. Ideale per club e agenzie.</div>
       </section>
@@ -107,39 +109,5 @@
     <footer>© OB1 Radar</footer>
   </div>
 
-  <!-- Paddle.js -->
-  <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
-  <script>
-    // Inizializza Paddle
-    Paddle.Environment.set('production');
-    Paddle.Initialize({ 
-      token: 'live_7c5da8decff27e2158b87f0a93b', // Il tuo client token
-      checkout: {
-        settings: {
-          allowedPaymentMethods: ["card", "paypal"],
-          locale: "it",
-          frameTarget: "self",
-          frameInitialHeight: 450,
-          frameStyle: "width: 100%; min-width: 312px; background-color: transparent; border: none;",
-          successUrl: "https://mtornani.github.io/OB1-Radar/success.html"
-        }
-      }
-    });
-
-    // Funzione per aprire checkout
-    function openCheckout(plan) {
-      const prices = {
-        monthly: 'pri_01k4ev94snz6naqdj8221qgh0q',  // €2.500/mese
-        annual: 'pri_01k4j50pa45x9t0gw887w3q9sz'    // €25.000/anno
-      };
-
-      Paddle.Checkout.open({
-        items: [{
-          priceId: prices[plan],
-          quantity: 1
-        }]
-      });
-    }
-  </script>
 </body>
 </html>

--- a/docs/success.html
+++ b/docs/success.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>OB1 · Pagamento ricevuto</title>
+  <style>
+    :root { --bg:#0b0d10; --fg:#e8eaed; --muted:#9aa0a6; --card:#15181c; --accent:#2563eb; }
+    html,body{margin:0;height:100%;background:var(--bg);color:var(--fg);font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial;}
+    .wrap{max-width:720px;margin:0 auto;padding:24px;}
+    .card{background:var(--card);border:1px solid #222831;border-radius:14px;padding:28px;text-align:center;}
+    h1{font-size:26px;margin:0 0 14px;}
+    p{margin:10px 0;}
+    .btn{display:inline-block;margin-top:18px;padding:12px 20px;border-radius:10px;background:var(--accent);border:none;color:#fff;font-weight:600;text-decoration:none;}
+    .btn:hover{filter:brightness(1.15)}
+    .muted{color:var(--muted);font-size:14px;margin-top:16px;}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <h1>✅ Pagamento ricevuto</h1>
+      <p>Grazie per aver attivato <b>OB1 Ouroboros Radar</b>.</p>
+      <p>La ricevuta ufficiale ti è stata inviata via <b>Paddle</b>.</p>
+      <hr style="border:none;border-top:1px solid #2a2f36;margin:20px 0;">
+      <p>Entro poche ore attiveremo:</p>
+      <ul style="text-align:left;display:inline-block;margin:0 auto;padding:0;list-style:disc inside;">
+        <li>Accesso ai CSV settimanali</li>
+        <li>Export certificati e report</li>
+        <li>Alert Telegram giornalieri</li>
+        <li>Supporto prioritario</li>
+      </ul>
+      <a class="btn" href="./index.html">↩ Torna al Radar</a>
+      <p class="muted">Per qualsiasi problema scrivi a <a href="mailto:info@matchanalysispro.online">info@matchanalysispro.online</a></p>
+    </div>
+  </div>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- replace JavaScript checkout buttons with direct Paddle v3 checkout links on the pricing page
- add a dark-themed success page for post-checkout redirects with contact details

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d2ffba867483218603735682f08ff0